### PR TITLE
ISAICP-6720: Handle field_name.entity case in entity query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,28 +13,26 @@ mysql:
 
 jobs:
   include:
-    # PHP 7.4
+
     - name: 'PHPCodeSniffer'
       php: 7.4
       env: TEST_SUITE=PHPCodeSniffer
 
     - name: 'PHPStan'
       php: 7.4
-      env: TEST_SUITE=PHPStan DRUPAL=~8.9.0 PHPUNIT=^7
-
-    # PHP 7.4
-    - name: 'PHPUnit with Drupal 8 on PHP 7.4'
-      php: 7.4
-      env: TEST_SUITE=PHPUnit DRUPAL=^8.9 PHPUNIT=^7
+      env: TEST_SUITE=PHPStan DRUPAL=^9.2 PHPUNIT=^9
 
     - name: 'PHPUnit with Drupal 9 on PHP 7.4'
       php: 7.4
-      env: TEST_SUITE=PHPUnit DRUPAL=^9.1 PHPUNIT=^9
+      env: TEST_SUITE=PHPUnit DRUPAL=^9.2 PHPUNIT=^9
 
-    # PHP 8
+    - name: 'PHPUnit with Drupal 9 on PHP 8.0'
+      php: 8.0
+      env: TEST_SUITE=PHPUnit DRUPAL=^9.2 PHPUNIT=^9
+
     - name: 'PHPUnit with Drupal 9 on PHP 8 nightly'
       php: nightly
-      env: TEST_SUITE=PHPUnit DRUPAL=^9.1 PHPUNIT=^9
+      env: TEST_SUITE=PHPUnit DRUPAL=^9.2 PHPUNIT=^9
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: 'PHPStan'
       php: 7.4
-      env: TEST_SUITE=PHPStan DRUPAL=^9.2 PHPUNIT=^9
+      env: TEST_SUITE=PHPStan DRUPAL=~8.9.20 PHPUNIT=^7
 
     - name: 'PHPUnit with Drupal 9 on PHP 7.4'
       php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,14 @@ mysql:
 
 jobs:
   include:
-    # PHP 7.3
+    # PHP 7.4
     - name: 'PHPCodeSniffer'
-      php: 7.3
+      php: 7.4
       env: TEST_SUITE=PHPCodeSniffer
 
     - name: 'PHPStan'
-      php: 7.3
+      php: 7.4
       env: TEST_SUITE=PHPStan DRUPAL=~8.9.0 PHPUNIT=^7
-
-    - name: 'PHPUnit with Drupal 8 on PHP 7.3'
-      php: 7.3
-      env: TEST_SUITE=PHPUnit DRUPAL=^8.9 PHPUNIT=^7
-
-    - name: 'PHPUnit with Drupal 9 on PHP 7.3'
-      php: 7.3
-      env: TEST_SUITE=PHPUnit DRUPAL=^9.1 PHPUNIT=^9
 
     # PHP 7.4
     - name: 'PHPUnit with Drupal 8 on PHP 7.4'

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "ml/json-ld": "^1.0"
   },
   "require-dev": {
+    "behat/mink": "~1.9.0",
     "composer/installers": "^1.7",
     "drupal/coder": "^8.3",
     "drupal/core": "^8.9 || ^9.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
     customRulesetUsed: true
     reportUnmatchedIgnoredErrors: false
-    excludes_analyse:
+    excludePaths:
         - ../testing_site/modules/sparql_entity_storage/vendor
 includes:
     - vendor/mglaman/phpstan-drupal/extension.neon

--- a/src/Entity/Query/Sparql/Query.php
+++ b/src/Entity/Query/Sparql/Query.php
@@ -404,7 +404,7 @@ class Query extends QueryBase implements SparqlQueryInterface {
    */
   protected function conditionGroupFactory($conjunction = 'AND') {
     $class = static::getClass($this->namespaces, 'SparqlCondition');
-    return new $class($conjunction, $this, $this->namespaces, $this->graphHandler, $this->fieldHandler, $this->languageManager);
+    return new $class($conjunction, $this, $this->namespaces, $this->fieldHandler, $this->languageManager);
   }
 
   /**

--- a/tests/src/Kernel/SparqlEntityQueryTest.php
+++ b/tests/src/Kernel/SparqlEntityQueryTest.php
@@ -71,6 +71,17 @@ class SparqlEntityQueryTest extends SparqlKernelTestBase {
   }
 
   /**
+   * Tests that the case field_ref.entity is handled.
+   */
+  public function testEntityColumns(): void {
+    $ids = array_keys($this->getQuery()->condition('reference.entity', $this->entities[1]->id())->execute());
+    $this->assertSame([
+      'http://vegetable.example.com/004',
+      'http://vegetable.example.com/009',
+    ], $ids);
+  }
+
+  /**
    * Tests basic functionality related to Id and bundle filtering.
    */
   public function testIdBundleFilters() {
@@ -635,7 +646,8 @@ class SparqlEntityQueryTest extends SparqlKernelTestBase {
   protected function getQuery(string $operator = 'AND'): SparqlQueryInterface {
     return $this->container->get('entity_type.manager')
       ->getStorage('sparql_test')
-      ->getQuery($operator);
+      ->getQuery($operator)
+      ->accessCheck(FALSE);
   }
 
 }


### PR DESCRIPTION
Quoting from `\Drupal\Core\Entity\Query\QueryInterface::condition()` documentation:

> (... )The column can be the reference property, usually "entity", for reference fields and that can be followed similarly by a field name and so on. Additionally, the target entity type can be specified by appending the ":target_entity_type_id" to  "entity".

Given, `field_ref` an entity reference field, the following entity query will crash:

```php
\Drupal::entityQuery('rdf_entity')->condition('field_ref.entity', 'http://example.com')->execute();
```

This is because, right now, the special `entity` column is not handled.
